### PR TITLE
Some fixes and improvement to Last hit marker

### DIFF
--- a/LastHitMarker/Program.cs
+++ b/LastHitMarker/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Remoting.Messaging;
 using Ensage;
 using Ensage.Common.Extensions;
 using SharpDX;
@@ -14,6 +15,11 @@ namespace LastHitMarker
         private static Hero _me;
         private static Bool _screenSizeLoaded = false;
         private static float _screenX;
+        private static Bool _textureLoaded = false;
+        private static DotaTexture _textureActiveCoin;
+        private static DotaTexture _textureActiveDeny;
+        private static DotaTexture _texturePassiveCoin;
+        private static DotaTexture _texturePassiveDeny;
         private static void Main()
         {
             Game.OnUpdate += Game_OnUpdate;
@@ -56,6 +62,7 @@ namespace LastHitMarker
                         if (CreepsDictionary.TryGetValue(creep, out creepType)) continue;
                         creepType = "passive";
                         CreepsDictionary.Add(creep, creepType);
+                        CreepsTeamDictionary.Add(creep, creep.Team);
                     }
                 }
                 else {
@@ -68,19 +75,34 @@ namespace LastHitMarker
         private static void Drawing_OnDraw(EventArgs args)
         {
             if (!Game.IsInGame || Game.GameTime > 1800)
+            {
+                if (CreepsDictionary.Count > 0) CreepsDictionary.Clear();
+                if (CreepsTeamDictionary.Count > 0) CreepsTeamDictionary.Clear();
                 return;
+            }
 
-            var creeps = ObjectMgr.GetEntities<Unit>().Where(creep => (creep.ClassID == ClassID.CDOTA_BaseNPC_Creep_Lane || creep.ClassID == ClassID.CDOTA_BaseNPC_Creep_Siege) && creep.IsSpawned).ToList();
-            foreach (var creep in creeps) {
+            if (!_textureLoaded)
+            {
+                _textureActiveCoin = Drawing.GetTexture("materials/ensage_ui/other/active_coin.vmat");
+                _textureActiveDeny = Drawing.GetTexture("materials/ensage_ui/other/active_deny.vmat");
+                _texturePassiveCoin = Drawing.GetTexture("materials/ensage_ui/other/passive_coin.vmat");
+                _texturePassiveDeny = Drawing.GetTexture("materials/ensage_ui/other/passive_deny.vmat");
+                _textureLoaded = true;
+            }
+
+            foreach (var keyPair in CreepsDictionary)
+            {
+                var creep = keyPair.Key;
+                string creepType = keyPair.Value;
+                if (!creep.IsVisible || !creep.IsAlive) continue;
+
                 Vector2 screenPos;
                 var enemyPos = creep.Position + new Vector3(0, 0, creep.HealthBarOffset);
                 if (!Drawing.WorldToScreen(enemyPos, out screenPos)) continue;
 
                 var start = screenPos + new Vector2(-5, -30);
 
-                string creepType;
                 Team creepTeam;
-                if (!CreepsDictionary.TryGetValue(creep, out creepType)) continue;
                 if (!CreepsTeamDictionary.TryGetValue(creep, out creepTeam)) continue;
 
                 if (!_screenSizeLoaded)
@@ -88,10 +110,10 @@ namespace LastHitMarker
                     _screenX = Drawing.Width / (float)1600 * (float)0.8;
                     _screenSizeLoaded = true;
                 }
-                
+
                 switch (creepType) {
-                    case "active": Drawing.DrawRect(start, creepTeam == _me.Team ? new Vector2(20 * _screenX, 20 * _screenX) : new Vector2(15*_screenX, 15*_screenX), creepTeam == _me.Team ? Drawing.GetTexture("materials/ensage_ui/other/active_deny.vmat") : Drawing.GetTexture("materials/ensage_ui/other/active_coin.vmat")); break;
-                    case "passive": Drawing.DrawRect(start, creepTeam == _me.Team ? new Vector2(20 * _screenX, 20 * _screenX) : new Vector2(15 * _screenX, 15 * _screenX), creepTeam == _me.Team ? Drawing.GetTexture("materials/ensage_ui/other/passive_deny.vmat") : Drawing.GetTexture("materials/ensage_ui/other/passive_coin.vmat")); break;
+                    case "active": Drawing.DrawRect(start, creepTeam == _me.Team ? new Vector2(20 * _screenX, 20 * _screenX) : new Vector2(15*_screenX, 15*_screenX), creepTeam == _me.Team ? _textureActiveDeny : _textureActiveCoin); break;
+                    case "passive": Drawing.DrawRect(start, creepTeam == _me.Team ? new Vector2(20 * _screenX, 20 * _screenX) : new Vector2(15 * _screenX, 15 * _screenX), creepTeam == _me.Team ? _texturePassiveDeny : _texturePassiveCoin); break;
                 }
             }
         }


### PR DESCRIPTION
Last Hit Marker - ADD: Texture Cache to improve performance
Last Hit Marker - FIX: Passive last hit creeps doesn't have team value, leading to not displaying passive last hit
Last Hit Marker - CHANGE: OnDraw loop through CreepDictionary instead of the whole list of every creep again
